### PR TITLE
Included missing imports for gradio and spaces in requirements.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ h5py
 rotary_embedding_torch
 diffusers
 timm
+gradio
+spaces


### PR DESCRIPTION
This fixes the following errors when running `app.py`:
import gradio as gr
import spaces

The more recent commit adds a `.gitattributes` file, which is needed for `git lfs pull` to work properly and download the .png files in `./assets`.