### PR TITLE
Fixed broken diffusion_path

### DIFF
--- a/configurations/huggingface.yaml
+++ b/configurations/huggingface.yaml
@@ -53,7 +53,7 @@ noise_level: random_all
 causal: True
 x_shape: [3, 360, 640]
 context_frames: 1
-diffusion_path: /mnt/xiaozeqi/worldmem_github/diffusion_only_2025-04-06-16-24-11_epoch1step720000.ckpt
+diffusion_path: yslan/worldmem_checkpoints/diffusion_only.ckpt
 vae_path: yslan/worldmem_checkpoints/vae_only.ckpt
 pose_predictor_path: yslan/worldmem_checkpoints/pose_prediction_model_only.ckpt
 next_frame_length: 1


### PR DESCRIPTION
Restored the local diffusion_path added by https://github.com/xizaoqu/WorldMem/commit/3e832e93f642d08c16cd6d435fca895578c1ed86 to "yslan/worldmem_checkpoints/diffusion_only.ckpt"